### PR TITLE
Change caching

### DIFF
--- a/.ebextensions/nginx.config
+++ b/.ebextensions/nginx.config
@@ -16,7 +16,6 @@ files:
                              ;
             proxy_cache_key  "$scheme://$host$request_uri";
             proxy_cache      main_cache;
-            proxy_cache_valid 200 1m;
             proxy_cache_valid 301 302 404 15m;
 
             map $http_upgrade $connection_upgrade {

--- a/dplaapi/handlers/v2.py
+++ b/dplaapi/handlers/v2.py
@@ -32,7 +32,7 @@ def items_key(params):
 
     def hashable(thing):
         if isinstance(thing, list):
-            return ','.join(thing)
+            return ','.join(sorted(thing))
         else:
             return thing
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ aiofiles==0.4.0
 apistar==0.5.41
 boto3==1.8.6
 botocore==1.11.6
+cachetools==2.1.0
 certifi==2018.8.24
 chardet==3.0.4
 click==6.7

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,8 @@ setup(name='dplaapi',
           'aiofiles~=0.3',
           'peewee~=3.6',
           'psycopg2-binary~=2.7',
-          'boto3~=1.8'
+          'boto3~=1.8',
+          'cachetools~=2.1.0'
       ],
       extras_require={
         'dev': [

--- a/tests/handlers/test_v2.py
+++ b/tests/handlers/test_v2.py
@@ -1050,3 +1050,9 @@ def test_compact_handles_missing_fields():
     }
     result = v2_handlers.compact(before.copy(), params)
     assert result == after
+
+
+def test_items_key():
+    params = {'api_key': 'a1b2c3', 'ids': ['d4', 'e5']}
+    result = v2_handlers.items_key(params)
+    assert result == (('api_key', 'a1b2c3'), ('ids', 'd4,e5'), 'v2_items')

--- a/tests/handlers/test_v2.py
+++ b/tests/handlers/test_v2.py
@@ -1053,6 +1053,7 @@ def test_compact_handles_missing_fields():
 
 
 def test_items_key():
-    params = {'api_key': 'a1b2c3', 'ids': ['d4', 'e5']}
+    params = {'api_key': 'a1b2c3', 'ids': ['e5', 'd4']}
     result = v2_handlers.items_key(params)
+    # Note that 'ids' is sorted
     assert result == (('api_key', 'a1b2c3'), ('ids', 'd4,e5'), 'v2_items')


### PR DESCRIPTION
Change caching because the original way prevented requests from being tracked. With Nginx caching, requests would never get back to the application so that it could log the request.  The new way uses cacheutils and a small in-memory TTL cache simply to prevent floods of repeat requests from causing a performance problem.
