### PR TITLE
Fix Google Analytics "events" post

### DIFF
--- a/dplaapi/analytics.py
+++ b/dplaapi/analytics.py
@@ -76,7 +76,7 @@ class GATracker(threading.Thread):
         data_provider = comma_del_string(doc.get('dataProvider', []))
         sr = doc.get('sourceResource', {})
         title = comma_del_string(sr.get('title', []))
-        return [('t', 'event'),
+        return [('t', 'event'), ('cid', self.api_key),
                 ('ec', 'View API Item : %s' % provider_name),
                 ('ea', data_provider),
                 ('el', '%s : %s' % (doc.get('id', ''), title)),

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -83,10 +83,12 @@ def test_GATracker_constructs_correct_event_data(monkeypatch, mocker):
     #  ('ea', 'Library of Y'),
     #  ('el', 'c3d4 : Document Two'),
     #  ('dh', 'example.org'), ('dp', '/?')]
-    body = "t=event&ec=View+API+Item+%3A+Partner+X&ea=Library+of+X&" \
-           "el=a1b2+%3A+Document+One&dh=example.org&dp=%2F%3F&v=1&tid=x\n" \
-           "t=event&ec=View+API+Item+%3A+Partner+X&ea=Library+of+Y&" \
-           "el=c3d4+%3A+Document+Two&dh=example.org&dp=%2F%3F&v=1&tid=x"
+    body = "t=event&cid=a1b2c3&ec=View+API+Item+%3A+Partner+X&" \
+           "ea=Library+of+X&el=a1b2+%3A+Document+One&dh=example.org&" \
+           "dp=%2F%3F&v=1&tid=x\n" \
+           "t=event&cid=a1b2c3&ec=View+API+Item+%3A+Partner+X&" \
+           "ea=Library+of+Y&el=c3d4+%3A+Document+Two&dh=example.org&" \
+           "dp=%2F%3F&v=1&tid=x"
     tracker().track_events()
     post_stub.assert_called_once_with(
         'http://www.google-analytics.com/batch', body)


### PR DESCRIPTION
Add missing "cid" parameter to payload. This was preventing GA from registering events.

I was disappointed to read at https://developers.google.com/analytics/devguides/collection/protocol/v1/reference that:

> The Measurement Protocol does not return an error code if the payload data was malformed, or if the data in the payload was incorrect or was not processed by Google Analytics.

It returns an HTTP 200 if you have bad parameters and it's going to ignore the POST! So I looked more closely at my parameters and this seems to make the events show up now.

