### PR TITLE
Add rights to q search

### DIFF
--- a/dplaapi/search_query.py
+++ b/dplaapi/search_query.py
@@ -64,7 +64,7 @@ fields_to_query = {
     'sourceResource.language.name': '1',
     'sourceResource.publisher': '1',
     'sourceResource.relation': '1',
-    'sourceResource.rights': None,
+    'sourceResource.rights': '1',
     'sourceResource.spatial': None,
     'sourceResource.spatial.coordinates': None,
     'sourceResource.spatial.country': '0.75',

--- a/tests/test_search_query.py
+++ b/tests/test_search_query.py
@@ -57,6 +57,7 @@ def test_query_string_clause_has_all_correct_fields_for_q_query():
         'sourceResource.language.name^1',
         'sourceResource.publisher^1',
         'sourceResource.relation^1',
+        'sourceResource.rights^1',
         'sourceResource.spatial.country^0.75',
         'sourceResource.spatial.county^1',
         'sourceResource.spatial.name^1',
@@ -71,7 +72,6 @@ def test_query_string_clause_has_all_correct_fields_for_q_query():
     ]
     got_fields = sq.query['query']['bool']['must'][0]['query_string']['fields']
     assert sorted(got_fields) == sorted(good_fields)
-
 
 
 def test_SearchQuery_has_source_clause_for_fields_constraint():

--- a/tests/test_search_query.py
+++ b/tests/test_search_query.py
@@ -48,7 +48,6 @@ def test_query_string_clause_has_all_correct_fields_for_q_query():
     good_fields = [
         'sourceResource.title^2',
         'sourceResource.description^0.75',
-        'sourceResource.subject.name^1',
         'sourceResource.collection.title^1',
         'sourceResource.collection.description^1',
         'sourceResource.contributor^1',
@@ -58,7 +57,11 @@ def test_query_string_clause_has_all_correct_fields_for_q_query():
         'sourceResource.language.name^1',
         'sourceResource.publisher^1',
         'sourceResource.relation^1',
+        'sourceResource.spatial.country^0.75',
+        'sourceResource.spatial.county^1',
         'sourceResource.spatial.name^1',
+        'sourceResource.spatial.region^1',
+        'sourceResource.spatial.state^0.75',
         'sourceResource.specType^1',
         'sourceResource.subject.name^1',
         'sourceResource.type^1',
@@ -67,7 +70,8 @@ def test_query_string_clause_has_all_correct_fields_for_q_query():
         'provider.name^1',
     ]
     got_fields = sq.query['query']['bool']['must'][0]['query_string']['fields']
-    assert got_fields.sort() == good_fields.sort()
+    assert sorted(got_fields) == sorted(good_fields)
+
 
 
 def test_SearchQuery_has_source_clause_for_fields_constraint():


### PR DESCRIPTION
There are two commits here. The first one fixes a flaw in the test for the fields that are queried when you do a `q=` search. The arrays in the test were not being compared correctly. The second commit is the actual one that adds `sourceResource.rights` (the freeform, provider-supplied rights field) to the fields that are queried for a `q=` search. This feature was requested by @samanthadpla because it was useful for the Gif It Up event, and the old API apparently enabled it.
