### PR TITLE
Allow quotes around URL parameters

### DIFF
--- a/dplaapi/types.py
+++ b/dplaapi/types.py
@@ -3,7 +3,7 @@ import apistar
 
 
 sr = 'SourceResource (Cultural Heritage Object)'
-url_match_pat = r'^https?://[-a-zA-Z0-9:%_\+.~#?&/=]+$'
+url_match_pat = r'^"?https?://[-a-zA-Z0-9:%_\+.~#?&/=]+"?$'
 
 items_params = {
     'q': apistar.validators.String(


### PR DESCRIPTION
Allow quotes around URL parameters like isShownAt. For example, `isShownAt=%22http://example.org/%22`