### PR TITLE
Do wildcard search on provider object

### DIFF
--- a/dplaapi/search_query.py
+++ b/dplaapi/search_query.py
@@ -128,7 +128,8 @@ field_or_subfield = {
 # We let the user query on some fields that are objects. We really mean
 # "field.*" ... or else Elasticsearch won't query its subfields.
 object_wildcards = {
-    'sourceResource.spatial': 'sourceResource.spatial.*'
+    'sourceResource.spatial': 'sourceResource.spatial.*',
+    'provider': 'provider.*'
 }
 
 


### PR DESCRIPTION
Given a query with `provider=X`, return the same result as `provider.name=` by using a wildcarded `fields` value in the Elasticsearch Query DSL.  Use `{'fields': ['provider.*']}`.