### PR TITLE
Add method to get a single random item from the index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ build/
 *.egg-info/
 
 dplaapi.zip
+
+.idea/

--- a/dplaapi/handlers/v2.py
+++ b/dplaapi/handlers/v2.py
@@ -89,7 +89,6 @@ def random(request):
                                  in request.query_params.items()})
 
     goodparams.update({'random': 'true'})
-    goodparams['page_size'] = 1
 
     sq = SearchQuery(goodparams)
     log.debug("Elasticsearch QUERY (Python dict):\n%s" % sq.query)

--- a/dplaapi/handlers/v2.py
+++ b/dplaapi/handlers/v2.py
@@ -105,7 +105,7 @@ def random(request):
                               request=request,
                               results=rv,
                               api_key=account.key,
-                              title='Fetch items')
+                              title='Fetch random item')
     else:
         task = None
 

--- a/dplaapi/handlers/v2.py
+++ b/dplaapi/handlers/v2.py
@@ -95,9 +95,6 @@ def random(request):
 
     result = items(sq)
 
-    if result['hits']['total'] == 0:
-        raise HTTPException(404)
-
     rv = {
         'count': result['hits']['total'],
         'docs': [hit['_source'] for hit in result['hits']['hits']]

--- a/dplaapi/queries/search_query.py
+++ b/dplaapi/queries/search_query.py
@@ -117,7 +117,7 @@ def single_field_fields_clause(field, boost, constraints):
 def is_field_related(param_name):
     return param_name in fields_to_query or param_name == 'q' \
            or param_name == 'ids' or param_name.endswith('.before') \
-           or param_name.endswith('.after') # or param_name == 'random'
+           or param_name.endswith('.after')
 
 
 def fields_and_constraints(params):

--- a/dplaapi/routes/v2.py
+++ b/dplaapi/routes/v2.py
@@ -14,5 +14,8 @@ routes = [
           endpoint=handlers.mlt),
     Route('/api_key/{email}',
           methods=['POST', 'OPTIONS'],
-          endpoint=handlers.api_key)
+          endpoint=handlers.api_key),
+    Route('/random',
+          methods=['GET', 'OPTIONS'],
+          endpoint=handlers.random)
 ]

--- a/dplaapi/types.py
+++ b/dplaapi/types.py
@@ -98,6 +98,12 @@ items_params = {
             description='API Key',
             pattern=r'^[a-f0-9]{32}$',
             allow_null=True),
+    'random': apistar.validators.String(
+            title='Random',
+            description='Random item',
+            enum=['true'],
+            allow_null=True
+    ),
     'id': apistar.validators.String(
             title='ID',
             description='DPLA Record ID',
@@ -450,7 +456,8 @@ mlt_params = {
     'sort_order': items_params['sort_order'],
     'sort_by_pin': items_params['sort_by_pin'],
     'callback': items_params['callback'],
-    'api_key': items_params['api_key']
+    'api_key': items_params['api_key'],
+    'random': items_params['random']
 }
 
 

--- a/dplaapi/types.py
+++ b/dplaapi/types.py
@@ -456,8 +456,7 @@ mlt_params = {
     'sort_order': items_params['sort_order'],
     'sort_by_pin': items_params['sort_by_pin'],
     'callback': items_params['callback'],
-    'api_key': items_params['api_key'],
-    'random': items_params['random']
+    'api_key': items_params['api_key']
 }
 
 


### PR DESCRIPTION
Adds feature to retrieve one record at random from the index.  Invoked by passing the `random: True` parameter. 
`q = dplaapi.queries.search_query.SearchQuery({'page': 1, 'page_size' : 1, 'random': True})` 

Tested by passing query to Postman. 
`{"sort": [{"_score": {"order": "desc"}}, {"id": {"order": "asc"}}], "query": {"function_score": {"random_score": {}}}, "from": 0, "size": 1}` 