### PR TITLE
increase max char limit for facets

### DIFF
--- a/dplaapi/types.py
+++ b/dplaapi/types.py
@@ -72,7 +72,7 @@ items_params = {
             title='Facets',
             description='Facets',
             min_length=2,
-            max_length=200,
+            max_length=300,
             pattern=r'^[a-zA-Z\.,]+',
             allow_null=True),
     'facet_size': apistar.validators.String(


### PR DESCRIPTION
This increases the maximum character length for a request involving facets.  This is necessary to accommodate three new facet fields in the QA app (see https://github.com/dpla/dpla-frontend/pull/970).  This has been tested locally.  