### PR TITLE
Lda vectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The application will be available with the following endpoints:
 * `http://localhost:8000/v2/items`
 * `http://localhost:8000/v2/items/<item ID or IDs>`
 * `http://localhost:8000/v2/items/<item ID or IDs>/mlt`
+* `http://localhost:8000/v2/items/<item ID>/lda`
 
 See [the API Codex](https://pro.dp.la/developers/api-codex) for usage.
 

--- a/dplaapi/handlers/v2.py
+++ b/dplaapi/handlers/v2.py
@@ -203,7 +203,7 @@ def flatten(the_list):
     don't work because they explode strings into arrays.
     """
     if the_list is None:
-        raise StopIteration
+        return []
     for el in the_list:
         if isinstance(el, list):
             for sub_el in flatten(el):

--- a/dplaapi/handlers/v2.py
+++ b/dplaapi/handlers/v2.py
@@ -528,7 +528,7 @@ async def lda(request):
     vector = json.loads(item_response.body)['docs'][0].get('ldaVector')
 
     if vector is None:
-        raise HTTPException(404, "Item does not have a LDA vector: %s"
+        raise HTTPException(500, "Item does not have a LDA vector: %s"
                             % single_id)
 
     vector_str = [str(s) for s in vector]

--- a/dplaapi/handlers/v2.py
+++ b/dplaapi/handlers/v2.py
@@ -532,7 +532,7 @@ async def lda(request):
                             % single_id)
 
     vector_str = [str(s) for s in vector]
-    goodparams.update({'vector': vector_str})
+    goodparams.update({'vector': vector_str, 'id': single_id})
 
     # Get items with similar lda vectors by making a second call to ES
     # This second call is tracked

--- a/dplaapi/handlers/v2.py
+++ b/dplaapi/handlers/v2.py
@@ -520,15 +520,16 @@ async def lda(request):
 
     response = response_object(item_rv, good_item_params, None)
 
-    # Get lda vector from first item (as string)
-    vector = json.dumps(json.loads(response.body)['docs'][0]['ldaVector'])
+    # Get lda vector from first item (as array of string)
+    vector = json.loads(response.body)['docs'][0]['ldaVector']
+    vector_str = [str(s) for s in vector]
 
     # Get items with similar lda vectors by making a second call to ES
     # This second call is tracked
 
     goodparams = LDAQueryType({k: v for [k, v]
                                in request.query_params.items()})
-    goodparams.update({'vector': vector})
+    goodparams.update({'vector': vector_str})
 
     result = lda_items(goodparams)
     log.debug('cache size: %d' % lda_cache.currsize)

--- a/dplaapi/handlers/v2.py
+++ b/dplaapi/handlers/v2.py
@@ -477,9 +477,14 @@ async def mlt(request):
 async def lda(request):
     """Cosine similarity for LDA vector"""
 
-    item = await specific_item(request)
+    response = await specific_item(request)
 
-    return item
+    vector = json.loads(response.body)['docs'][0]['ldaVector']
+
+    print('Vector:')
+    print(vector)
+
+    return response
 
 
 async def api_key(request):

--- a/dplaapi/handlers/v2.py
+++ b/dplaapi/handlers/v2.py
@@ -551,9 +551,15 @@ async def lda(request):
     }
 
     if account and not account.staff:
-        track(request, rv, account.key, 'LDA Vector Similarity search results')
+        task = BackgroundTask(track,
+                              request=request,
+                              results=rv,
+                              api_key=account.key,
+                              title='LDA Vector Similarity search results')
+    else:
+        task = None
 
-    return response_object(rv, goodparams)
+    return response_object(rv, goodparams, task)
 
 
 async def api_key(request):

--- a/dplaapi/handlers/v2.py
+++ b/dplaapi/handlers/v2.py
@@ -527,7 +527,7 @@ async def lda(request):
     # Parse item vector
     doc = json.loads(item_response.body)['docs'][0]
     vector = doc.get('ldaVector')
-    bucket = doc.get('ldaBucket')[0]
+    bucket = doc.get('ldaBucket')
 
     # TODO address case of item not having ldaBucket
 

--- a/dplaapi/handlers/v2.py
+++ b/dplaapi/handlers/v2.py
@@ -496,7 +496,8 @@ async def lda_item(item_id):
     if not re.match(r'[a-f0-9]{32}$', item_id):
         raise HTTPException(400, "Bad ID: %s" % item_id)
 
-    item_params = {'ids': [item_id], 'fields': 'ldaVector,ldaBucket', 'page_size': 1}
+    item_params = \
+        {'ids': [item_id], 'fields': 'ldaVector,ldaBucket', 'page_size': 1}
     result = search_items(item_params)
 
     log.debug('cache size: %d' % search_cache.currsize)
@@ -536,7 +537,10 @@ async def lda(request):
                             % single_id)
 
     vector_str = [str(s) for s in vector]
-    goodparams.update({'vector': vector_str, 'bucket': bucket, 'id': single_id})
+
+    goodparams.update({'vector': vector_str,
+                       'bucket': bucket,
+                       'id': single_id})
 
     # Get items with similar lda vectors by making a second call to ES
     # This second call is tracked

--- a/dplaapi/handlers/v2.py
+++ b/dplaapi/handlers/v2.py
@@ -496,7 +496,7 @@ async def lda_item(item_id):
     if not re.match(r'[a-f0-9]{32}$', item_id):
         raise HTTPException(400, "Bad ID: %s" % item_id)
 
-    item_params ={'ids': [item_id], 'fields': 'ldaVector', 'page_size': 1}
+    item_params = {'ids': [item_id], 'fields': 'ldaVector', 'page_size': 1}
     result = search_items(item_params)
 
     log.debug('cache size: %d' % search_cache.currsize)
@@ -528,7 +528,8 @@ async def lda(request):
     vector = json.loads(item_response.body)['docs'][0].get('ldaVector')
 
     if vector is None:
-        raise HTTPException(404, "Item does not have a LDA vector: %s" % single_id)
+        raise HTTPException(404, "Item does not have a LDA vector: %s"
+                            % single_id)
 
     vector_str = [str(s) for s in vector]
     goodparams.update({'vector': vector_str})

--- a/dplaapi/handlers/v2.py
+++ b/dplaapi/handlers/v2.py
@@ -474,6 +474,14 @@ async def mlt(request):
     return response_object(rv, goodparams)
 
 
+async def lda(request):
+    """Cosine similarity for LDA vector"""
+
+    item = await specific_item(request)
+
+    return item
+
+
 async def api_key(request):
     """Create a new API key"""
 

--- a/dplaapi/queries/lda_query.py
+++ b/dplaapi/queries/lda_query.py
@@ -14,14 +14,15 @@ query_skel = {
         'script_score': {
             'query': {
                 'bool': {
-                    'must': {
+                    'should': {
                         'match': {'ldaBucket': ''},
                     },
                     'must_not': {
                         'term': {
                             'id': ''
                         }
-                    }
+                    },
+                    'minimum_should_match': 1
                 }
             },
             'script': {
@@ -67,7 +68,7 @@ class LDAQuery(BaseQuery):
 
         script_score['query']['bool']['must_not']['term']['id'] = params['id']
 
-        script_score['query']['bool']['must']['match']['ldaBucket'] = params['bucket']
+        script_score['query']['bool']['should']['match']['ldaBucket'] = params['bucket']
 
         if 'fields' in params:
             self.query['_source'] = params['fields'].split(',')

--- a/dplaapi/queries/lda_query.py
+++ b/dplaapi/queries/lda_query.py
@@ -1,0 +1,59 @@
+"""
+dplaapi.lda_query
+~~~~~~~~~~~~~~~~~
+
+Cosine similarity search on LDA vector
+"""
+
+from .base_query import BaseQuery
+
+
+query_skel = {
+    'query': {
+        'script_score': {
+            'query': {
+                'match_all': {}
+            },
+            'script': {
+                'source': 'cosineSimilarity(params.queryVector, doc.ldaVector)',
+                'params': {
+                    'queryVector': []
+                }
+            }
+        }
+    },
+    'sort': [
+        {'_score': {'order': 'desc'}},
+        {'id': {'order': 'asc'}}
+    ]
+}
+
+
+class LDAQuery(BaseQuery):
+    """Elasticsearch Cosine Similarity query on LDA vector
+
+    Representing the JSON request body of the _search POST request.
+    The `query' attribute is a dict that represents the JSON of the
+    Elasticsearch query.
+
+    Instance attributes:
+    - query: The dict that will be serialized to JSON for the query.
+    """
+    def __init__(self, params: dict):
+        """
+        Arguments:
+        - params: The request's querystring parameters
+        """
+        self.query = query_skel.copy()
+        # like_list = [{'_type': 'item', '_id': x}
+        #              for x in params['ids']]
+        self.query['query']['script']['params']['queryVector'] = params['vector']
+
+        if 'fields' in params:
+            self.query['_source'] = params['fields'].split(',')
+
+        self.query['from'] = (params['page'] - 1) * params['page_size']
+        self.query['size'] = params['page_size']
+
+        if 'sort_by' in params:
+            self.add_sort_clause(params)

--- a/dplaapi/queries/lda_query.py
+++ b/dplaapi/queries/lda_query.py
@@ -15,7 +15,7 @@ query_skel = {
             'query': {
                 'bool': {
                     'should': {
-                        'match': {'ldaBucket': ''},
+                        'match': [{'ldaBucket': ''}],
                     },
                     'must_not': {
                         'term': {
@@ -68,7 +68,7 @@ class LDAQuery(BaseQuery):
 
         script_score['query']['bool']['must_not']['term']['id'] = params['id']
 
-        script_score['query']['bool']['should']['match']['ldaBucket'] = params['bucket']
+        script_score['query']['bool']['should'] = [{'match': {'ldaBucket': params['bucket']}}]
 
         if 'fields' in params:
             self.query['_source'] = params['fields'].split(',')

--- a/dplaapi/queries/lda_query.py
+++ b/dplaapi/queries/lda_query.py
@@ -7,13 +7,15 @@ Cosine similarity search on LDA vector
 
 from .base_query import BaseQuery
 
+# max terminate_after is 3878 based on testing
+
 query_skel = {
     'query': {
         'script_score': {
             'query': {
                 'bool': {
                     'must': {
-                        'match_all': {},
+                        'match': {'sourceResource.subject.name': 'spoon'},
                     },
                     'must_not': {
                         'term': {

--- a/dplaapi/queries/lda_query.py
+++ b/dplaapi/queries/lda_query.py
@@ -15,7 +15,7 @@ query_skel = {
             'query': {
                 'bool': {
                     'must': {
-                        'match': {'sourceResource.subject.name': 'spoon'},
+                        'match': {'ldaBucket': ''},
                     },
                     'must_not': {
                         'term': {
@@ -28,7 +28,8 @@ query_skel = {
                 'source':
                     'cosineSimilarity(params.queryVector, doc.ldaVector)',
                 'params': {
-                    'queryVector': []
+                    'queryVector': [],
+                    'size': 100
                 }
             }
         }
@@ -65,6 +66,8 @@ class LDAQuery(BaseQuery):
         script_score['script']['params']['queryVector'] = vector
 
         script_score['query']['bool']['must_not']['term']['id'] = params['id']
+
+        script_score['query']['bool']['must']['match']['ldaBucket'] = params['bucket']
 
         if 'fields' in params:
             self.query['_source'] = params['fields'].split(',')

--- a/dplaapi/queries/lda_query.py
+++ b/dplaapi/queries/lda_query.py
@@ -7,7 +7,6 @@ Cosine similarity search on LDA vector
 
 from .base_query import BaseQuery
 
-
 query_skel = {
     'query': {
         'script_score': {
@@ -27,7 +26,7 @@ query_skel = {
         {'id': {'order': 'asc'}}
     ]
 }
-
+# TODO add more params, start at 1
 
 class LDAQuery(BaseQuery):
     """Elasticsearch Cosine Similarity query on LDA vector
@@ -45,9 +44,10 @@ class LDAQuery(BaseQuery):
         - params: The request's querystring parameters
         """
         self.query = query_skel.copy()
-        # like_list = [{'_type': 'item', '_id': x}
-        #              for x in params['ids']]
-        self.query['query']['script']['params']['queryVector'] = params['vector']
+
+        vector_str = params['vector'].rstrip(']').lstrip('[').split(',')
+        vector = [float(s) for s in vector_str]
+        self.query['query']['script_score']['script']['params']['queryVector'] = vector
 
         if 'fields' in params:
             self.query['_source'] = params['fields'].split(',')

--- a/dplaapi/queries/lda_query.py
+++ b/dplaapi/queries/lda_query.py
@@ -11,7 +11,16 @@ query_skel = {
     'query': {
         'script_score': {
             'query': {
-                'match_all': {}
+                'bool': {
+                    'must': {
+                        'match_all': {},
+                    },
+                    'must_not': {
+                        'term': {
+                            'id': ''
+                        }
+                    }
+                }
             },
             'script': {
                 'source':
@@ -50,6 +59,8 @@ class LDAQuery(BaseQuery):
         vector = [float(s) for s in vector_str]
         self.query['query']['script_score']['script']['params']['queryVector']\
             = vector
+
+        self.query['query']['script_score']['query']['bool']['must_not']['term']['id'] = params['id']
 
         if 'fields' in params:
             self.query['_source'] = params['fields'].split(',')

--- a/dplaapi/queries/lda_query.py
+++ b/dplaapi/queries/lda_query.py
@@ -45,7 +45,8 @@ class LDAQuery(BaseQuery):
         """
         self.query = query_skel.copy()
 
-        vector_str = params['vector'].rstrip(']').lstrip('[').split(',')
+        # vector_str = params['vector'].rstrip(']').lstrip('[').split(',')
+        vector_str = params['vector']
         vector = [float(s) for s in vector_str]
         self.query['query']['script_score']['script']['params']['queryVector'] = vector
 

--- a/dplaapi/queries/lda_query.py
+++ b/dplaapi/queries/lda_query.py
@@ -68,7 +68,10 @@ class LDAQuery(BaseQuery):
 
         script_score['query']['bool']['must_not']['term']['id'] = params['id']
 
-        script_score['query']['bool']['should'] = [{'match': {'ldaBucket': params['bucket']}}]
+        bucket_list = [{'match': {'ldaBucket': x}}
+                     for x in params['bucket']]
+
+        script_score['query']['bool']['should'] = bucket_list
 
         if 'fields' in params:
             self.query['_source'] = params['fields'].split(',')

--- a/dplaapi/queries/lda_query.py
+++ b/dplaapi/queries/lda_query.py
@@ -14,7 +14,8 @@ query_skel = {
                 'match_all': {}
             },
             'script': {
-                'source': 'cosineSimilarity(params.queryVector, doc.ldaVector)',
+                'source':
+                    'cosineSimilarity(params.queryVector, doc.ldaVector)',
                 'params': {
                     'queryVector': []
                 }
@@ -26,7 +27,7 @@ query_skel = {
         {'id': {'order': 'asc'}}
     ]
 }
-# TODO add more params, start at 1
+
 
 class LDAQuery(BaseQuery):
     """Elasticsearch Cosine Similarity query on LDA vector
@@ -47,7 +48,8 @@ class LDAQuery(BaseQuery):
 
         vector_str = params['vector']
         vector = [float(s) for s in vector_str]
-        self.query['query']['script_score']['script']['params']['queryVector'] = vector
+        self.query['query']['script_score']['script']['params']['queryVector']\
+            = vector
 
         if 'fields' in params:
             self.query['_source'] = params['fields'].split(',')

--- a/dplaapi/queries/lda_query.py
+++ b/dplaapi/queries/lda_query.py
@@ -69,7 +69,7 @@ class LDAQuery(BaseQuery):
         script_score['query']['bool']['must_not']['term']['id'] = params['id']
 
         bucket_list = [{'match': {'ldaBucket': x}}
-                     for x in params['bucket']]
+                       for x in params['bucket']]
 
         script_score['query']['bool']['should'] = bucket_list
 

--- a/dplaapi/queries/lda_query.py
+++ b/dplaapi/queries/lda_query.py
@@ -45,7 +45,6 @@ class LDAQuery(BaseQuery):
         """
         self.query = query_skel.copy()
 
-        # vector_str = params['vector'].rstrip(']').lstrip('[').split(',')
         vector_str = params['vector']
         vector = [float(s) for s in vector_str]
         self.query['query']['script_score']['script']['params']['queryVector'] = vector

--- a/dplaapi/queries/lda_query.py
+++ b/dplaapi/queries/lda_query.py
@@ -57,10 +57,12 @@ class LDAQuery(BaseQuery):
 
         vector_str = params['vector']
         vector = [float(s) for s in vector_str]
-        self.query['query']['script_score']['script']['params']['queryVector']\
-            = vector
 
-        self.query['query']['script_score']['query']['bool']['must_not']['term']['id'] = params['id']
+        script_score = self.query['query']['script_score']
+
+        script_score['script']['params']['queryVector'] = vector
+
+        script_score['query']['bool']['must_not']['term']['id'] = params['id']
 
         if 'fields' in params:
             self.query['_source'] = params['fields'].split(',')

--- a/dplaapi/queries/mlt_query.py
+++ b/dplaapi/queries/mlt_query.py
@@ -12,7 +12,7 @@ query_skel = {
     'query': {
         'more_like_this': {
             'fields': [
-                'sourceResource.title.mlt', 'sourceResource.subject.mlt'
+                'sourceResource.title.mlt', 'sourceResource.subject.mlt', 'sourceResource.description.mlt'
             ],
             'min_term_freq': 1,
             'min_doc_freq': 5,

--- a/dplaapi/queries/mlt_query.py
+++ b/dplaapi/queries/mlt_query.py
@@ -52,3 +52,6 @@ class MLTQuery(BaseQuery):
 
         self.query['from'] = (params['page'] - 1) * params['page_size']
         self.query['size'] = params['page_size']
+
+        if 'sort_by' in params:
+            self.add_sort_clause(params)

--- a/dplaapi/queries/mlt_query.py
+++ b/dplaapi/queries/mlt_query.py
@@ -12,7 +12,9 @@ query_skel = {
     'query': {
         'more_like_this': {
             'fields': [
-                'sourceResource.title.mlt', 'sourceResource.subject.mlt', 'sourceResource.description.mlt'
+                'sourceResource.title.mlt',
+                'sourceResource.subject.mlt',
+                'sourceResource.description.mlt'
             ],
             'min_term_freq': 1,
             'min_doc_freq': 5,

--- a/dplaapi/queries/mlt_query.py
+++ b/dplaapi/queries/mlt_query.py
@@ -52,6 +52,3 @@ class MLTQuery(BaseQuery):
 
         self.query['from'] = (params['page'] - 1) * params['page_size']
         self.query['size'] = params['page_size']
-
-        if 'sort_by' in params:
-            self.add_sort_clause(params)

--- a/dplaapi/queries/search_query.py
+++ b/dplaapi/queries/search_query.py
@@ -15,8 +15,7 @@ query_skel_search = {
     'sort': [
         {'_score': {'order': 'desc'}},
         {'id': {'order': 'asc'}}
-    ],
-    'track_total_hits': 'true'
+    ]
 }
 
 query_skel_specific_ids = {

--- a/dplaapi/routes/v2.py
+++ b/dplaapi/routes/v2.py
@@ -18,7 +18,7 @@ routes = [
     Route('/random',
           methods=['GET', 'OPTIONS'],
           endpoint=handlers.random),
-    Route('/items/{id_or_ids}/lda',
+    Route('/items/{single_id}/lda',
           methods=['GET', 'OPTIONS'],
           endpoint=handlers.lda)
 ]

--- a/dplaapi/routes/v2.py
+++ b/dplaapi/routes/v2.py
@@ -17,5 +17,8 @@ routes = [
           endpoint=handlers.api_key),
     Route('/random',
           methods=['GET', 'OPTIONS'],
-          endpoint=handlers.random)
+          endpoint=handlers.random),
+    Route('/items/{id_or_ids}/lda',
+          methods=['GET', 'OPTIONS'],
+          endpoint=handlers.lda)
 ]

--- a/dplaapi/types.py
+++ b/dplaapi/types.py
@@ -474,6 +474,7 @@ mlt_params = {
 }
 
 lda_params = {
+    'id': items_params['id'],
     'fields': items_params['fields'],
     'page': items_params['page'],
     'page_size': items_params['page_size'],

--- a/dplaapi/types.py
+++ b/dplaapi/types.py
@@ -473,6 +473,16 @@ mlt_params = {
     'api_key': items_params['api_key']
 }
 
+lda_params = {
+    'fields': items_params['fields'],
+    'page': items_params['page'],
+    'page_size': items_params['page_size'],
+    'sort_by': items_params['sort_by'],
+    'sort_order': items_params['sort_order'],
+    'callback': items_params['callback'],
+    'api_key': items_params['api_key']
+}
+
 
 class BaseQueryType(dict):
     params_specification = {}  # To be overridden
@@ -539,3 +549,10 @@ class MLTQueryType(BaseQueryType):
 
     def __init__(self, *args):
         super(MLTQueryType, self).__init__(*args)
+
+
+class LDAQueryType(BaseQueryType):
+    params_specification = lda_params
+
+    def __init__(self, *args):
+        super(LDAQueryType, self).__init__(*args)

--- a/dplaapi/types.py
+++ b/dplaapi/types.py
@@ -477,8 +477,6 @@ lda_params = {
     'fields': items_params['fields'],
     'page': items_params['page'],
     'page_size': items_params['page_size'],
-    'sort_by': items_params['sort_by'],
-    'sort_order': items_params['sort_order'],
     'callback': items_params['callback'],
     'api_key': items_params['api_key']
 }

--- a/tests/handlers/test_v2.py
+++ b/tests/handlers/test_v2.py
@@ -490,6 +490,7 @@ def test_mlt_rejects_invalid_params(monkeypatch, mocker):
 
 # lda tests ...
 
+
 @pytest.mark.usefixtures('disable_auth')
 def test_lda_calls_lda_items_correctly(monkeypatch):
     """/v2/items/<item>/lda calls lda_items with dictionary"""

--- a/tests/handlers/test_v2.py
+++ b/tests/handlers/test_v2.py
@@ -537,7 +537,7 @@ def test_lda_returns_not_found_err_for_missing_ldaVector(monkeypatch, mocker):
 
     path = '/v2/items/13283cd2bd45ef385aae962b144c7e6a/lda'
     response = client.get(path)
-    assert response.status_code == 404
+    assert response.status_code == 500
 
 # end lda tests.
 

--- a/tests/queries/test_lda_query.py
+++ b/tests/queries/test_lda_query.py
@@ -4,11 +4,11 @@ from dplaapi.queries.lda_query import LDAQuery
 from dplaapi.types import LDAQueryType
 
 
-def test_LDAQuery_produces_query_with_like_clause():
+def test_LDAQuery_produces_query_with_queryVector_clause():
     """LDAQuery produces a query with a "vector" clause
     with correct datatype"""
     params = LDAQueryType()
-    params.update({'vector': ['0.1', '0.3'], 'id': 'foo'})
+    params.update({'vector': ['0.1', '0.3'], 'id': 'foo', 'bucket': 'bar'})
     q = LDAQuery(params)
     query_vector = \
         q.query['query']['script_score']['script']['params']['queryVector']
@@ -18,7 +18,7 @@ def test_LDAQuery_produces_query_with_like_clause():
 def test_LDAQuery_has_correct_default_sort():
     """The search query without a sort requested has the correct 'sort'"""
     params = LDAQueryType()
-    params.update({'vector': ['0.1', '0.3'], 'id': 'foo'})
+    params.update({'vector': ['0.1', '0.3'], 'id': 'foo', 'bucket': 'bar'})
     q = LDAQuery(params)
     assert q.query['sort'] == [
         {'_score': {'order': 'desc'}},
@@ -30,6 +30,6 @@ def test_LDAQuery_has_source_clause_for_fields_parameter():
     """If there's a "fields" query param, there's a "_source" property in the
     Elasticsearch query."""
     params = LDAQueryType({'fields': 'id'})
-    params.update({'vector': ['0.1', '0.3'], 'id': 'foo'})
+    params.update({'vector': ['0.1', '0.3'], 'id': 'foo', 'bucket': 'bar'})
     q = LDAQuery(params)
     assert q.query['_source'] == ['id']

--- a/tests/queries/test_lda_query.py
+++ b/tests/queries/test_lda_query.py
@@ -8,7 +8,7 @@ def test_LDAQuery_produces_query_with_like_clause():
     """LDAQuery produces a query with a "vector" clause
     with correct datatype"""
     params = LDAQueryType()
-    params.update({'vector': ['0.1', '0.3']})
+    params.update({'vector': ['0.1', '0.3'], 'id': 'foo'})
     q = LDAQuery(params)
     query_vector = \
         q.query['query']['script_score']['script']['params']['queryVector']
@@ -18,7 +18,7 @@ def test_LDAQuery_produces_query_with_like_clause():
 def test_LDAQuery_has_correct_default_sort():
     """The search query without a sort requested has the correct 'sort'"""
     params = LDAQueryType()
-    params.update({'vector': ['0.1', '0.3']})
+    params.update({'vector': ['0.1', '0.3'], 'id': 'foo'})
     q = LDAQuery(params)
     assert q.query['sort'] == [
         {'_score': {'order': 'desc'}},
@@ -30,6 +30,6 @@ def test_LDAQuery_has_source_clause_for_fields_parameter():
     """If there's a "fields" query param, there's a "_source" property in the
     Elasticsearch query."""
     params = LDAQueryType({'fields': 'id'})
-    params.update({'vector': ['0.1', '0.3']})
+    params.update({'vector': ['0.1', '0.3'], 'id': 'foo'})
     q = LDAQuery(params)
     assert q.query['_source'] == ['id']

--- a/tests/queries/test_lda_query.py
+++ b/tests/queries/test_lda_query.py
@@ -5,11 +5,13 @@ from dplaapi.types import LDAQueryType
 
 
 def test_LDAQuery_produces_query_with_like_clause():
-    """LDAQuery produces a query with a "vector" clause with an array of float"""
+    """LDAQuery produces a query with a "vector" clause
+    with correct datatype"""
     params = LDAQueryType()
     params.update({'vector': ['0.1', '0.3']})
     q = LDAQuery(params)
-    assert q.query['query']['script_score']['script']['params']['queryVector'] == [0.1, 0.3]
+    query_vector = q.query['query']['script_score']['script']['params']['queryVector']
+    assert query_vector == [0.1, 0.3]
 
 
 def test_LDAQuery_has_correct_default_sort():
@@ -21,6 +23,7 @@ def test_LDAQuery_has_correct_default_sort():
         {'_score': {'order': 'desc'}},
         {'id': {'order': 'asc'}},
     ]
+
 
 def test_LDAQuery_has_source_clause_for_fields_parameter():
     """If there's a "fields" query param, there's a "_source" property in the

--- a/tests/queries/test_lda_query.py
+++ b/tests/queries/test_lda_query.py
@@ -1,0 +1,23 @@
+"""Test dplaapi.lda_query"""
+
+from dplaapi.queries.lda_query import LDAQuery
+from dplaapi.types import LDAQueryType
+
+
+def test_LDAQuery_produces_query_with_like_clause():
+    """LDAQuery produces a query with a "vector" clause with an array of float"""
+    params = LDAQueryType()
+    params.update({'vector': ['0.1', '0.3']})
+    q = LDAQuery(params)
+    assert q.query['query']['script_score']['script']['params']['queryVector'] == [0.1, 0.3]
+
+
+def test_LDAQuery_has_correct_default_sort():
+    """The search query without a sort requested has the correct 'sort'"""
+    params = LDAQueryType()
+    params.update({'vector': ['0.1', '0.3']})
+    q = LDAQuery(params)
+    assert q.query['sort'] == [
+        {'_score': {'order': 'desc'}},
+        {'id': {'order': 'asc'}},
+    ]

--- a/tests/queries/test_lda_query.py
+++ b/tests/queries/test_lda_query.py
@@ -21,3 +21,11 @@ def test_LDAQuery_has_correct_default_sort():
         {'_score': {'order': 'desc'}},
         {'id': {'order': 'asc'}},
     ]
+
+def test_LDAQuery_has_source_clause_for_fields_parameter():
+    """If there's a "fields" query param, there's a "_source" property in the
+    Elasticsearch query."""
+    params = LDAQueryType({'fields': 'id'})
+    params.update({'vector': ['0.1', '0.3']})
+    q = LDAQuery(params)
+    assert q.query['_source'] == ['id']

--- a/tests/queries/test_lda_query.py
+++ b/tests/queries/test_lda_query.py
@@ -10,7 +10,8 @@ def test_LDAQuery_produces_query_with_like_clause():
     params = LDAQueryType()
     params.update({'vector': ['0.1', '0.3']})
     q = LDAQuery(params)
-    query_vector = q.query['query']['script_score']['script']['params']['queryVector']
+    query_vector = \
+        q.query['query']['script_score']['script']['params']['queryVector']
     assert query_vector == [0.1, 0.3]
 
 


### PR DESCRIPTION
This adds a new route to the API.  Given an item id, it returns items with similar LDA vectors.

Implementation
* The new route is in the format `http://localhost:8000/v2/items/<item ID>/lda`
* The api makes an initial call to ES to get the `ldaVector` for the item.  It makes a second call to get similar items using the `ldaVector`.
* Supported parameters are: `page`, `page_size`, and `fields`.

MLT
* This adds `description` to the "More like this" feature to facilitate comparison with the LDA feature.

This also fixes code that was causing a test to fail, unrelated to this PR:
* https://github.com/dpla/dplaapi/compare/lda-vectors?expand=1#diff-367309d75ef4e54228dbeef444b26b4bR220