### PR TITLE
track exact search count

### DIFF
--- a/dplaapi/queries/search_query.py
+++ b/dplaapi/queries/search_query.py
@@ -16,7 +16,8 @@ query_skel_search = {
     'sort': [
         {'_score': {'order': 'desc'}},
         {'id': {'order': 'asc'}}
-    ]
+    ],
+    'track_total_hits': 'true'
 }
 
 query_skel_specific_ids = {


### PR DESCRIPTION
This prepares for upgrading to ES7, without breaking ES6.

In order to get exact results counts in ES7, a request must now contain the parameter `track_total_hits: 'true'`.  Otherwise, it cuts off at 10,000. See https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.html#track-total-hits-10000-default

In ES6, exact results counts are the default behavior and `track_total_hits` is ignored.

This has been tested locally against the production ES6 and a local ES7.  It would be good for someone to sanity check this to make sure it doesn't break when run against ES6.