### PR TITLE
Feature/tag filter

### DIFF
--- a/dplaapi/analytics.py
+++ b/dplaapi/analytics.py
@@ -96,9 +96,9 @@ def comma_del_string(list_or_string):
 
 
 async def track(request, results, api_key, title):
-        tid = os.getenv('GA_TID')
-        if tid:
-            GATracker(tid, request, results, api_key, title).run()
+    tid = os.getenv('GA_TID')
+    if tid:
+        GATracker(tid, request, results, api_key, title).run()
 
 
 def post(url, body):

--- a/dplaapi/queries/search_query.py
+++ b/dplaapi/queries/search_query.py
@@ -30,7 +30,7 @@ query_skel_specific_ids = {
 # The key is the field name and the value is the boost, and also indicates if
 # the field will be used in a "simple search" "q=" query.
 #
-fields_to_query = {
+fields_to_query = { 
     'dataProvider': '1',
     'hasView': None,
     'hasView.@id': None,
@@ -293,6 +293,9 @@ class SearchQuery(BaseQuery):
             size = facet_size(constraints)
             self.query['aggs'] = facets_clause(constraints['facets'], size)
 
+        if 'filter' in constraints:
+            self.filter_clause(constraints['filter'])
+
         if 'random' in constraints:
             # Override all other query parameters and return one random record
             self.query["query"] = {
@@ -301,6 +304,11 @@ class SearchQuery(BaseQuery):
                 }
             }
             self.query["size"] = 1
+
+    def filter_clause(self, filter):
+        # TODO Support multiple filters
+        clause = { 'term': {k: v} for (k,v) in filter.items() }
+        self.query['query']['bool']['filter'] = clause
 
     def add_query_string_clause(self, field, term, constraints):
         clause = {

--- a/dplaapi/queries/search_query.py
+++ b/dplaapi/queries/search_query.py
@@ -11,7 +11,7 @@ from dplaapi.facets import facets
 from dplaapi.field_or_subfield import field_or_subfield
 from .base_query import BaseQuery
 
-query_skel_search = { 
+query_skel_search = {
     'sort': [
         {'_score': {'order': 'desc'}},
         {'id': {'order': 'asc'}}
@@ -30,7 +30,7 @@ query_skel_specific_ids = {
 # The key is the field name and the value is the boost, and also indicates if
 # the field will be used in a "simple search" "q=" query.
 #
-fields_to_query = { 
+fields_to_query = {
     'dataProvider': '1',
     'hasView': None,
     'hasView.@id': None,
@@ -263,19 +263,20 @@ class SearchQuery(BaseQuery):
 
         if not fields.keys():
             self.query = query_skel_search.copy()
-#   "query": {
-#     "bool": {
-#       "must": {
-#         "match_all": {}
-#       },
-#       "filter": {
-#         "term": {
-#           "status": "active"
-#         }
-#       }
-#     }
-#   }
-            self.query['query'] = {'bool': { self.bool_type: [ {'match_all': {} }] }}
+            #   "query": {
+            #     "bool": {
+            #       "must": {
+            #         "match_all": {}
+            #       },
+            #       "filter": {
+            #         "term": {
+            #           "status": "active"
+            #         }
+            #       }
+            #     }
+            #   }
+            self.query['query'] = {'bool': {self.bool_type:
+                                            [{'match_all': {}}]}}
 
         elif 'ids' in fields:
             self.query = query_skel_specific_ids.copy()
@@ -306,8 +307,8 @@ class SearchQuery(BaseQuery):
             self.query['aggs'] = facets_clause(constraints['facets'], size)
 
         if ('filter.field' in constraints and 'filter.value' in constraints):
-            self.filter_clause(constraints['filter.field'], 
-                constraints['filter.value'])
+            self.filter_clause(constraints['filter.field'],
+                               constraints['filter.value'])
 
         if 'random' in constraints:
             # Override all other query parameters and return one random record
@@ -320,8 +321,10 @@ class SearchQuery(BaseQuery):
 
     def filter_clause(self, filter_field, filter_value):
         # TODO Support multiple filters
-        # clause = { 'term': {k: v} for (k,v) in filter.items() }
-        self.query['query']['bool']['filter'] = { 'term': { filter_field: filter_value} }
+        # clause = {'term': {k: v} for (k,v) in filter.items() }
+        self.query['query']['bool']['filter'] = {'term':
+                                                 {filter_field:
+                                                  filter_value}}
 
     def add_query_string_clause(self, field, term, constraints):
         clause = {

--- a/dplaapi/types.py
+++ b/dplaapi/types.py
@@ -24,6 +24,20 @@ items_params = {
             max_length=200,
             pattern=r'^[a-zA-Z\.,@]+',
             allow_null=True),
+    'filter.field': apistar.validators.String(
+            title='Fields',
+            description='Field to filter by',
+            min_length=2,
+            max_length=200,
+            pattern=r'^[a-zA-Z\.,@]+',
+            allow_null=True),
+    'filter.value': apistar.validators.String(
+            title='Fields',
+            description='Value to filter by',
+            min_length=2,
+            max_length=200,
+            pattern=r'^[a-zA-Z\.,@]+',
+            allow_null=True),
     'page': apistar.validators.String(
             title='Page',
             description='Page Number',

--- a/tests/handlers/test_v2.py
+++ b/tests/handlers/test_v2.py
@@ -385,7 +385,7 @@ async def test_multiple_items_calls_BackgroundTask(monkeypatch,
 async def test_multiple_items_strips_lone_star_vals(monkeypatch, mocker):
 
     def mock_items(*argv):
-            return minimal_good_response
+        return minimal_good_response
 
     def mock_account(*argv):
         return models.Account(key='a1b2c3', email='x@example.org')

--- a/tests/queries/test_search_query.py
+++ b/tests/queries/test_search_query.py
@@ -12,8 +12,8 @@ def test_SearchQuery_produces_match_all_for_no_query_terms():
     """SearchQuery produces 'match_all' syntax if there are no search terms"""
     params = types.ItemsQueryType()
     sq = search_query.SearchQuery(params)
-    assert 'match_all' in sq.query['query']
-    assert 'bool' not in sq.query['query']
+    assert 'match_all' in str(sq.query)
+    assert 'bool' in sq.query['query']
 
 
 def test_SearchQuery_produces_bool_query_for_query_terms():
@@ -87,7 +87,7 @@ def test_SearchQuery_can_handle_match_all_and_fields():
     """A correct ES query is generated for a match_all() with a _source prop"""
     params = types.ItemsQueryType({'fields': 'id'})
     sq = search_query.SearchQuery(params)
-    assert 'match_all' in sq.query['query']
+    assert 'match_all' in str(sq.query)
     assert '_source' in sq.query
 
 


### PR DESCRIPTION
 Add support for filtering query results. Uses two additional query parameters, `filter.field` and `filter.value`. Most common use case is filtering by `provider.@id` for DPLA local. 

Ex. to get only ESDN records 
`localhost:8000/v2/items?api_key=filter.field=provider.@id&filter.value=http://dp.la/api/contributor/esdn` 