### PR TITLE
Necropolis integration

### DIFF
--- a/Development.md
+++ b/Development.md
@@ -101,8 +101,8 @@ $ git push origin master X.Y.N stable
 You can run the following series of commands when you're working on the code.
 ```
 $ cd /path/to/dplaapi
-$ PYTHONPATH=. ES_BASE=&lt;url&gt; gunicorn -k uvicorn.workers.UvicornWorker \
-  --log-level=debug --reload dplaapi:app
+$ PYTHONPATH=. ES_BASE=&lt;url&gt; NECRO_BASE=&lt;url&gt; gunicorn -k \
+uvicorn.workers.UvicornWorker --log-level=debug --reload dplaapi:app
 ```
 That works well if you're iterating over changes to the files and want to see
 how they work. The server will reload if you modify files.
@@ -120,6 +120,7 @@ $ cd /path/to/dplaapi
 $ docker run -d -p 9200:9200  dplatech/dplaapi_elasticsearch:latest
 $ docker run -d -p 5432:5432  dplatech/dplaapi_postgresql:latest
 $ PYTHONPATH=. ES_BASE=http://localhost:9200/dpla_alias \
+  NECRO_BASE=http://localhost:9200/necropolis \
   gunicorn -k uvicorn.workers.UvicornWorker --log-level=debug \
   --reload dplaapi:app
 ```

--- a/README.md
+++ b/README.md
@@ -47,8 +47,11 @@ See [Development.md](./Development.md) for more ways to run the application.
 
 The application recognizes the following environment variables.
 
-* `ES_BASE` (required!):  The base URL of the Elasticsearch index, including the
-  path to the index
+* `ES_BASE` (required!):  The base URL of the main Elasticsearch index, including
+  the path to the index.
+* `NECRO_BASE` (required!):  The base URL of the Elasticsearch index that holds
+  tombstones for items no longer in DPLA under their old ids.  Include the
+  path to the index.
 * `APP_LOG_LEVEL`: The logging level of the `dplaapi` application; as distinct
   from the middleware, e.g. `uvicorn`.  ("debug" | "info" | "warning" |
   "error" | "critical"). Defaults to "debug".

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
             - .:/opt/dplaapi
         environment:
             ES_BASE: http://elasticsearch:9200/dpla_alias
+            NECRO_BASE: http://elasticsearch:9200/necropolis
             APP_LOG_LEVEL: info
             POSTGRES_HOST: postgres
             POSTGRES_USER: dplaapi

--- a/dplaapi/__init__.py
+++ b/dplaapi/__init__.py
@@ -36,6 +36,11 @@ if not ES_BASE:
     log.warning('ES_BASE env var is not defined. Elasticsearch queries will '
                 'not work!')
 
+NECRO_BASE = os.getenv('NECRO_BASE')
+if not NECRO_BASE:
+    log.warning('NECRO_BASE env var is not defined. Elasticsearch queries to '
+                'necropolis will not work!')
+
 
 def http_exception_handler(request, exc):
     # We assume that an HTTPException, which has been raised by our code,

--- a/dplaapi/handlers/v2.py
+++ b/dplaapi/handlers/v2.py
@@ -44,7 +44,7 @@ def items_key(params):
     return tuple(sorted(items)) + ('v2_items',)
 
 
-def items(query, necro = False):
+def items(query, necro=False):
     """Return "item" records from a search query
 
     The search query could either be a typical SearchQuery or a MLTQuery
@@ -456,12 +456,11 @@ async def specific_item(request):
 
     else:
         if doc_count != 0:
-            rv.update(docs = [hit['_source'] for hit in
-                              result['hits']['hits']])
+            rv.update(docs=[hit['_source'] for hit in result['hits']['hits']])
 
         if inactive_doc_count != 0:
-            rv.update(inactive_docs = [hit['_source'] for hit in
-                                       necro_result['hits']['hits']])
+            rv.update(inactive_docs=[hit['_source'] for hit in
+                                     necro_result['hits']['hits']])
 
     if account and not account.staff:
         task = BackgroundTask(track,

--- a/dplaapi/handlers/v2.py
+++ b/dplaapi/handlers/v2.py
@@ -85,7 +85,7 @@ def search_items(params):
 
 
 def search_necro(params):
-    """Get "item" records
+    """Get "item" records from necropolis
 
     Arguments:
     - params: Dict of querystring or path parameters

--- a/dplaapi/handlers/v2.py
+++ b/dplaapi/handlers/v2.py
@@ -54,7 +54,7 @@ def items(query, necro = False):
     - query:  instance of SearchQuery or MLTQuery, which has a `query'
               property.
     """
-    base = dplaapi.ES_BASE if necro == False else dplaapi.NECRO_BASE
+    base = dplaapi.ES_BASE if necro is False else dplaapi.NECRO_BASE
 
     try:
         resp = requests.post("%s/_search" % base, json=query.query)
@@ -456,7 +456,8 @@ async def specific_item(request):
 
     else:
         if doc_count != 0:
-            rv.update(docs = [hit['_source'] for hit in result['hits']['hits']])
+            rv.update(docs = [hit['_source'] for hit in
+                              result['hits']['hits']])
 
         if inactive_doc_count != 0:
             rv.update(inactive_docs = [hit['_source'] for hit in

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import pytest
 @pytest.fixture(scope='function', autouse=True)
 def disable_env_vars(monkeypatch):
     monkeypatch.delenv('ES_BASE', raising=False)
+    monkeypatch.delenv('NECRO_BASE', raising=False)
     monkeypatch.delenv('APP_LOG_LEVEL', raising=False)
     monkeypatch.delenv('DISABLE_AUTH', raising=False)
     monkeypatch.delenv('EMAIL_FROM', raising=False)

--- a/tests/handlers/test_v2.py
+++ b/tests/handlers/test_v2.py
@@ -42,7 +42,7 @@ minimal_good_response = {
 }
 
 
-minimal_necro_good_response = {
+minimal_necro_response = {
     'took': 5,
     'timed_out': False,
     'shards': {'total': 3, 'successful': 3, 'skipped': 0, 'failed': 0},
@@ -542,7 +542,7 @@ async def test_specific_item_passes_ids_to_necropolis(monkeypatch, mocker):
         return minimal_good_response
 
     def mock_search_necro(*args):
-        return minimal_necro_good_response
+        return minimal_necro_response
 
     monkeypatch.setattr(v2_handlers, 'search_items', mock_search_items)
     monkeypatch.setattr(v2_handlers, 'search_necro', mock_search_necro)
@@ -702,7 +702,7 @@ async def test_specific_items_formats_response_metadata(monkeypatch, mocker):
         return minimal_good_response
 
     def mock_necro(*argv):
-        return minimal_necro_good_response
+        return minimal_necro_response
 
     monkeypatch.setattr(requests, 'post', mock_es_post_response_200)
     monkeypatch.setattr(v2_handlers, 'search_items', mock_items)
@@ -720,8 +720,7 @@ async def test_specific_items_formats_response_metadata(monkeypatch, mocker):
     assert result['docs'] == \
            [hit['_source'] for hit in minimal_good_response['hits']['hits']]
     assert result['inactive_docs'] == \
-           [hit['_source'] for hit in
-            minimal_necro_good_response['hits']['hits']]
+           [hit['_source'] for hit in minimal_necro_response['hits']['hits']]
 
 
 # end specific_items tests.

--- a/tests/handlers/test_v2.py
+++ b/tests/handlers/test_v2.py
@@ -41,6 +41,7 @@ minimal_good_response = {
     }
 }
 
+
 minimal_necro_good_response = {
     'took': 5,
     'timed_out': False,
@@ -159,8 +160,10 @@ def mock_disabled_Account_get(*args, **kwargs):
 def mock_not_found_Account_get(*args, **kwargs):
     raise DoesNotExist()
 
+
 def mock_search_necro_w_no_results(*args, **kwargs):
     return {'hits': {'total': {'value': 0}}}
+
 
 def get_request(path, querystring=None, path_params=None):
     rv = {'type': 'http', 'method': 'GET', 'path': path, 'query_string': b''}
@@ -605,7 +608,8 @@ async def test_specific_item_accepts_callback_querystring_param(monkeypatch,
         return minimal_good_response
 
     monkeypatch.setattr(v2_handlers, 'items', mock_items)
-    monkeypatch.setattr(v2_handlers, 'search_necro', mock_search_necro_w_no_results)
+    monkeypatch.setattr(v2_handlers, 'search_necro',
+                        mock_search_necro_w_no_results)
     ids = '13283cd2bd45ef385aae962b144c7e6a'
     path_params = {'id_or_ids': ids}
     query_string = 'callback=f'
@@ -714,9 +718,10 @@ async def test_specific_items_formats_response_metadata(monkeypatch, mocker):
     assert result['count'] == 1
     assert result['inactive_count'] == 1
     assert result['docs'] == \
-        [hit['_source'] for hit in minimal_good_response['hits']['hits']]
+           [hit['_source'] for hit in minimal_good_response['hits']['hits']]
     assert result['inactive_docs'] == \
-           [hit['_source'] for hit in minimal_necro_good_response['hits']['hits']]
+           [hit['_source'] for hit in
+            minimal_necro_good_response['hits']['hits']]
 
 
 # end specific_items tests.

--- a/tests/handlers/test_v2.py
+++ b/tests/handlers/test_v2.py
@@ -717,10 +717,10 @@ async def test_specific_items_formats_response_metadata(monkeypatch, mocker):
     # See minimal_good_response above
     assert result['count'] == 1
     assert result['inactive_count'] == 1
-    assert result['docs'] == \
-           [hit['_source'] for hit in minimal_good_response['hits']['hits']]
-    assert result['inactive_docs'] == \
-           [hit['_source'] for hit in minimal_necro_response['hits']['hits']]
+    assert result['docs'] == [hit['_source'] for hit in
+                              minimal_good_response['hits']['hits']]
+    assert result['inactive_docs'] == [hit['_source'] for hit in
+                                       minimal_necro_response['hits']['hits']]
 
 
 # end specific_items tests.

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -26,6 +26,7 @@ def mock_validation_failure(*args, **kwargs):
 def mock_search_items_w_no_results(*args, **kwargs):
     return {'hits': {'total': {'value': 0}}}
 
+
 def mock_search_necro_w_no_results(*args, **kwargs):
     return {'hits': {'total': {'value': 0}}}
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -26,6 +26,9 @@ def mock_validation_failure(*args, **kwargs):
 def mock_search_items_w_no_results(*args, **kwargs):
     return {'hits': {'total': {'value': 0}}}
 
+def mock_search_necro_w_no_results(*args, **kwargs):
+    return {'hits': {'total': {'value': 0}}}
+
 
 @pytest.fixture(scope='function')
 def disable_auth():
@@ -56,6 +59,8 @@ def test_validation_errors_are_handled_correctly(monkeypatch):
 def test_thrown_http_errors_are_handled_correctly(monkeypatch):
     monkeypatch.setattr(v2_handlers, 'search_items',
                         mock_search_items_w_no_results)
+    monkeypatch.setattr(v2_handlers, 'search_necro',
+                        mock_search_necro_w_no_results)
     response = client.get('/v2/items/13283cd2bd45ef385aae962b144c7e6a')
     assert response.status_code == 404
     assert response.headers['content-type'] == ok_content_type


### PR DESCRIPTION
This integrates the necropolis data for requests for one or more item ID.

The following screenshots are from a my browser window with a local deployment.

E.g. response for an item that is **no longer in DPLA**:

![Screen Shot 2020-07-24 at 11 40 13 AM](https://user-images.githubusercontent.com/3615206/88409970-b5b32000-cda3-11ea-9d2b-6a5fb1197e35.png)

E.g. response for an item that is **in DPLA** (with some fields collapsed for readability):

![Screen Shot 2020-07-24 at 11 40 29 AM](https://user-images.githubusercontent.com/3615206/88409978-b8157a00-cda3-11ea-8507-ff2583ed8eb4.png)

E.g. response for a request for two item, **one still in DPLA and one not** (with some fields collapsed for readability):

![Screen Shot 2020-07-24 at 11 50 50 AM](https://user-images.githubusercontent.com/3615206/88410192-075baa80-cda4-11ea-93ca-06b995e88ccc.png)

